### PR TITLE
feat: add pre-commit on ssl-vice project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.20.0
+    hooks:
+    -   id: pyupgrade
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.12.3
+  hooks:
+    - id: ruff-check
+      args: [ --fix ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /root/ssl-VICE
 COPY . .
 
 # Instala dependências Python
+RUN pip install pre-commit
 RUN pip install --upgrade pip setuptools wheel packaging scikit-build
 RUN pip install -r requirements.txt
 RUN pip install protobuf==3.20.*


### PR DESCRIPTION
This pull request adds pre-commit tests in SSL-VICE project. the hooks used in the tests are listed below:

- Pre Commit Hooks: 
   - trailing-whitespace: remove end-of-file whitespaces
   - end-of-file-fixer: 
   - check-yaml: check .yaml archives sintax
   - check-added-large-files: block commits with large files
  
- PyUpgrade: automatically upgrade syntax for newer python versions

-  Ruff: linter for python projects
