### PR TITLE
feat: new implementations in control.py to play halt and controll refinament

### DIFF
--- a/launch/real_one.py
+++ b/launch/real_one.py
@@ -8,7 +8,6 @@ def generate_launch_description():
             Node(
                 package="vision",
                 executable="visionNode",
-                parameters=[{"ip": "224.5.23.2", "port": 10020, "verbose": False}],
             ),
             Node(
                 package="control_unit",
@@ -22,14 +21,14 @@ def generate_launch_description():
                 package="new_movement",
                 executable="driver",
             ),
-            Node(
-                package="strategy",
-                executable="strategyNode",
-            ),
-            Node(
-                package="gui_interpreter",
-                executable="apiNode",
-            ),
+            # Node(
+            #     package="strategy",
+            #     executable="strategyNode",
+            # ),
+            # Node(
+            #     package="gui_interpreter",
+            #     executable="apiNode",
+            # ),
             Node(
                 package="referee",
                 executable="referee_node",
@@ -37,7 +36,11 @@ def generate_launch_description():
             ),
             Node(
                 package="hardware_messenger",
-                executable="harware"
+                executable="hardware"
+            ),
+            Node(
+                package="strategy_command_gui",
+                executable="strategy_gui",
             )
         ]
     )

--- a/src/control/control/control.py
+++ b/src/control/control/control.py
@@ -1,7 +1,7 @@
 import rclpy
 from new_movement.entities.States import State, Vector2D
 from rclpy.node import Node
-
+from strategy.behaviour import TaskStatus
 from control.p_controller import PController
 from control.pid_controller import RobotTrajectoryController
 from system_interfaces.msg import ControlCommand, GameState, RobotCommand, TeamCommand
@@ -14,7 +14,21 @@ from system_interfaces.srv import (
 
 )
 
+class CheckState(Node):
+    def __init__(self, desired_states):
+        super().__init__("check_state")
+        self.desired_states = desired_states
+        self.referee_command = None
+        self.create_subscription(GameState, "game_state", self.game_state_callback, 10)
 
+    def game_state_callback(self, msg: GameState):
+        self.referee_command = msg.referee.command
+
+    def is_desired_state(self):
+
+        if self.referee_command in self.desired_states:
+            return True
+    
 class Controller(Node):
     """Simplified controller node.
 
@@ -63,7 +77,22 @@ class Controller(Node):
         self.last_time = self.get_clock().now()
         self.create_timer(0.01, self.timer_callback)  # 100 Hz
 
+        #Referee Command
+        self.referee_command = None
+        commands = ['TIMEOUT_BLUE', 'TIMEOUT_YELLOW', 'HALT']
+        self.check_halt = CheckState(commands)
 
+    def halt_velocities(self):
+        if self.latest_command is not None:
+            for cmd in self.latest_command.command:
+                cmd.velocity_x = 0.0
+                cmd.velocity_y = 0.0
+
+    def reset_all_controllers(self):
+        for robot_id in list(self.robot_controller.trajectory_controllers.keys()):
+            self.robot_controller.reset_controller(robot_id)
+
+            
     def receive_command(self, msg: ControlCommand):
         self.latest_command = msg
 
@@ -105,7 +134,17 @@ class Controller(Node):
         if self.latest_command is None:
             return
 
-        # config is polled periodically in _poll_game_config
+        if self.check_halt.is_desired_state():
+            self.robot_controller.update_params(0.0, 0.0, 0.0)
+            self.halt_velocities()  
+            self.reset_all_controllers()  
+        else:
+            self.robot_controller.update_params(
+                self.robot_controller.default_kp,
+                self.robot_controller.default_ki,
+                self.robot_controller.default_kd
+            )
+        
 
         now = self.get_clock().now()
         dt = (now - self.last_time).nanoseconds / 1e9
@@ -164,12 +203,21 @@ class Controller(Node):
         return resp
 
     def update_kp_angular_callback(self, req, resp):
-        if req.kp >= 0:
-            self.orientation_controller.kp = req.kp
+        commands = ['TIMEOUT_BLUE', 'TIMEOUT_YELLOW','HALT']
+
+        if self.referee_command == None:
+            resp.success = False
+
+        if self.referee_command in commands:
+            self.orientation_controller.kp = 0.0 
             resp.success = True
         else:
-            resp.success = False
-        return resp
+            if req.kp >= 0:
+                self.orientation_controller.kp = req.kp
+                resp.success = True
+            else:
+                resp.success = False
+            return resp
 
     def update_kick_callback(self, req, resp):
         robot_id = int(req.id)

--- a/src/hardware_messenger/hardware_messenger/hardware_publisher.py
+++ b/src/hardware_messenger/hardware_messenger/hardware_publisher.py
@@ -73,10 +73,10 @@ class HardwarePublisher(Node):
         for robot in command.robots:
             robot_command = self.encode_command(
                 robot.robot_id,
-                int(robot.linear_velocity_x),
-                int(robot.linear_velocity_y),
-                int(robot.angular_velocity),
-                int(robot.orientation),
+                int(robot.linear_velocity_x) * 1000,
+                int(-robot.linear_velocity_y) * 1000,
+                int(robot.angular_velocity) * 1000,
+                int(robot.orientation) * 1000,
                 int(robot.kick),
             )
 

--- a/src/hardware_messenger/setup.py
+++ b/src/hardware_messenger/setup.py
@@ -20,6 +20,7 @@ setup(
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
+            'hardware = hardware_messenger.hardware_publisher:main',
         ],
     },
 )

--- a/src/vision/vision/vision_node.py
+++ b/src/vision/vision/vision_node.py
@@ -23,9 +23,9 @@ class Vision(Node):
         # Parameters settings.
         self.declare_parameter("ip", "224.5.23.2")
         # Visão real
-        # self.declare_parameter("port", 10006)
+        self.declare_parameter("port", 10006)
         # Grsim
-        self.declare_parameter('port', 10020)
+        # self.declare_parameter('port', 10020)
         self.declare_parameter("verbose", False)
         # Optional local interface IP to bind/join multicast (e.g., 192.168.0.10). If empty uses INADDR_ANY.
         self.declare_parameter("interface_ip", "")


### PR DESCRIPTION
This pull request introduces several changes to improve control logic around referee commands, refines hardware communication, and updates launch configuration for the robot system. The main focus is on halting robot actions during specific referee states, correcting hardware messaging, and updating which nodes are launched for the real robot setup.

**Control logic improvements:**

* Added a new `CheckState` class in `control.py` to monitor referee commands and determine if the system should halt based on states like `TIMEOUT_BLUE`, `TIMEOUT_YELLOW`, or `HALT`. The main controller now uses this to zero velocities and reset controllers during these states. [[1]](diffhunk://#diff-90dbb50b2147e45c2237302ffb0c47011c27a6303f35dd161bc9d24cf74e1242R17-R30) [[2]](diffhunk://#diff-90dbb50b2147e45c2237302ffb0c47011c27a6303f35dd161bc9d24cf74e1242R80-R94) [[3]](diffhunk://#diff-90dbb50b2147e45c2237302ffb0c47011c27a6303f35dd161bc9d24cf74e1242L108-R147)
* Updated the `update_kp_angular_callback` logic to set the angular controller's `kp` to zero and block changes when in halt states, ensuring the robot does not rotate during timeouts or halt.

**Hardware communication fixes:**

* Modified `hardware_publisher.py` so that robot velocity and orientation values are correctly scaled by 1000 before encoding, and the y-velocity is negated to match hardware expectations.
* Added a new entry point for the hardware messenger in `setup.py`, enabling launch via the `hardware` console script.

**Launch configuration updates:**

* Updated `real_one.py` launch file: removed parameters from the vision node, commented out legacy strategy and GUI interpreter nodes, fixed a typo in the hardware messenger node, and added the new `strategy_command_gui` node. [[1]](diffhunk://#diff-cf37c5075c44cde012a97688ee6edbc3adbf4185ec37b15d0406052449ab1867L11) [[2]](diffhunk://#diff-cf37c5075c44cde012a97688ee6edbc3adbf4185ec37b15d0406052449ab1867L25-R43)

**Vision node parameter adjustments:**

* Changed the default port for the real vision node to `10006` and commented out the previous Grsim port setting, clarifying which configuration is active.