### PR TITLE
Feat/manual controller

### DIFF
--- a/launch/real_one.py
+++ b/launch/real_one.py
@@ -22,10 +22,10 @@ def generate_launch_description():
                 package="new_movement",
                 executable="driver",
             ),
-            Node(
-                package="strategy",
-                executable="strategyNode",
-            ),
+            # Node(
+            #     package="strategy",
+            #     executable="strategyNode",
+            # ),
             Node(
                 package="gui_interpreter",
                 executable="apiNode",
@@ -38,6 +38,10 @@ def generate_launch_description():
             Node(
                 package="hardware_messenger",
                 executable="hardware"
-            )
+            ),
+             Node(
+                package="strategy_command_gui",
+                executable="strategy_gui",
+            ),
         ]
     )

--- a/launch/sim_one.py
+++ b/launch/sim_one.py
@@ -6,9 +6,9 @@ def generate_launch_description():
     return LaunchDescription(
         [
             Node(
-                package="vision",
-                executable="visionNode",
-                parameters=[{"ip": "224.5.23.2", "port": 10020, "verbose": False}],
+               package="vision",
+               executable="visionNode",
+               parameters=[{"ip": "224.5.23.2", "port": 10020, "verbose": False}],
             ),
             Node(
                 package="control_unit",
@@ -18,34 +18,38 @@ def generate_launch_description():
                 package="control",
                 executable="controller",
             ),
-            Node(
-                package="new_movement",
-                executable="driver",
-            ),
+            # Node(
+            #     package="new_movement",
+            #     executable="driver",
+            # ),
             Node(
                 package="grsim_messenger",
                 executable="grsim_publisher_node",
             ),
-            Node(
-                package="strategy",
-                executable="strategyNode",
-            ),
-            Node(
-                package="gui_interpreter",
-                executable="apiNode",
-            ),
-            Node(
-                 package="referee",
-                 executable="referee_node",
-                 parameters=[{"forward_port": 10003, "verbose": False}],
-             ),
+            #Node(
+            #    package="strategy",
+            #    executable="strategyNode",
+            #),
             # Node(
-            #     package="strategy_command_gui",
-            #     executable="strategy_gui"
+            #     package="gui_interpreter",
+            #     executable="apiNode",
             # ),
             # Node(
-            #     package="hardware_messenger",
-            #     executable="hardware"
-            # )
+            #      package="referee",
+            #      executable="referee_node",
+            #      parameters=[{"forward_port": 10003, "verbose": False}],
+            #  ),
+            # Node(
+            #      package="strategy_command_gui",
+            #      executable="strategy_gui"
+            # ),
+            Node(
+                package="manual_command",
+                executable="manual_node",
+            ),
+            Node(
+                 package="hardware_messenger",
+                 executable="hardware"
+            )
         ]
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ numpy
 pytest
 pytest-mock
 pytest-cov
+inputs
+evdev

--- a/src/control/control/control.py
+++ b/src/control/control/control.py
@@ -47,7 +47,7 @@ class Controller(Node):
 
         # Controllers
         self.robot_controller = RobotTrajectoryController()
-        self.orientation_controller = PController(kp=0.5, max_output=1.5)
+        self.orientation_controller = PController(kp=1, max_output=2)
         self.target_orientations = {}
 
         # ROS Interfaces

--- a/src/grsim_messenger/setup.py
+++ b/src/grsim_messenger/setup.py
@@ -11,7 +11,7 @@ setup(
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
     ],
-    install_requires=['setuptools'],
+    install_requires=['setuptools', 'evdev'],
     zip_safe=True,
     maintainer='ararabots',
     maintainer_email='ararabots@gmail.com',

--- a/src/manual_command/manual_command/manual.py
+++ b/src/manual_command/manual_command/manual.py
@@ -1,99 +1,383 @@
+import math
 import rclpy
 from rclpy.node import Node
-from pynput import keyboard
 from threading import Thread
-from time import time
+from time import time, sleep
 
-from system_interfaces.msg import TeamCommand, RobotCommand
-from grsim_messenger.inverse_kinematics import apply_inverse_kinematics
+from system_interfaces.msg import TeamCommand, RobotCommand, VisionMessage
+from system_interfaces.srv import SetOrientation
+from sensor_msgs.msg import Joy
+
+import evdev
+from evdev import list_devices, InputDevice, ecodes
+
+
+desired_acc_x = 0.0
+desired_acc_y = 0.0
+desired_acc_t = 0.0
+
+robot_theta = 0.0
+
+
+def set_robot_orientation(theta: float) -> None:
+    """Atualiza a orientação global do robô (em radianos).
+
+    Chamável externamente para atualizar a orientação usada no controle field-centric.
+    """
+    global robot_theta
+    robot_theta = float(theta)
 
 
 class ManualCommand(Node):
     def __init__(self) -> None:
         super().__init__("manual_command")
+
+        self.declare_parameter("robot_id", 0)
+        self.robot_id = int(self.get_parameter("robot_id").value)
         self.command_publisher = self.create_publisher(TeamCommand, "commandTopic", 10)
-        self.create_timer(1 / 60, self.publish_command)
-        self.key_press_times = {}
-        self.velocities = {"w": 0.0, "s": 0.0, "a": 0.0, "d": 0.0, "q": 0.0, "e": 0.0}
-        self.max_velocity = 3.0  # Maximum velocity limit
-        self.acceleration_rate = 0.5  # Rate at which velocity increases
-        self.decay_rate = 0.01  # Rate at which velocity decays
+        self.create_timer(1.0 / 60.0, self.update_and_publish)
 
-    def publish_command(self):
-        self.get_logger().info("Publishing command")
-        command = self.create_command()
-        self.command_publisher.publish(command)
+        self.create_subscription(Joy, "joy", self._joy_callback, 10)
 
-    def create_command(self):
-        vx = self.calculate_velocity("w", False) + self.calculate_velocity("s", True)
-        vy = self.calculate_velocity("a", False) + self.calculate_velocity("d", True)
-        vt = self.calculate_velocity("q", False) + self.calculate_velocity("e", True)
-        print(vx, vy, vt)
-        print(type(apply_inverse_kinematics(vx, vy, vt)))
-        [print(f"{i}\t") for i in apply_inverse_kinematics(vx, vy, vt)]
+        self.vx = 0.0
+        self.vy = 0.0
+        self.vt = 0.0
+
+        self.max_velocity = 1.5
+        self.max_angular_velocity = 6.0
+        self.max_acceleration = 3.0
+        self.max_angular_acceleration = 6.0
+
+        self._last_time = time()
+        self._last_log_time = time()
+
+        # Detect evdev event device (preferred). Fallback is /joy topic only.
+        backend = None
+        evdev_path = None
+        if evdev is not None:
+            devs = list_devices()
+            for p in devs:
+                d = InputDevice(p)
+                caps = d.capabilities()
+                if ecodes.EV_ABS in caps:
+                    backend = "evdev"
+                    evdev_path = p
+                    break
+
+        if backend == "evdev":
+            t = Thread(target=self._evdev_thread, args=(evdev_path,), daemon=True)
+            t.start()
+        else:
+            pass
+
+        self.create_subscription(VisionMessage, "visionTopic", self._vision_callback, 10)
+
+        self._got_gamepad_event = False
+        self._seen_codes = set()
+        self._axis_pos = {"x": 0.0, "y": 0.0, "t": 0.0, "rx": 0.0, "ry": 0.0}
+        self._axis_last_time = {"x": 0.0, "y": 0.0, "t": 0.0, "rx": 0.0, "ry": 0.0}
+        self._evdev_code_map = {}
+        self.dead_input_timeout = 0.6
+        self.dead_input_timeout_long = 5.0
+        self.decel = 2.0
+        self.angular_decel = 6.0
+        self.declare_parameter("set_orientation_service", "set_orientation")
+        svc_name = str(self.get_parameter("set_orientation_service").value)
+        self._set_orientation_client = self.create_client(SetOrientation, svc_name)
+        self._orientation_service_warned = False
+        self._orientation_service_ready = False
+        if self._set_orientation_client is not None:
+            thr = Thread(target=self._orientation_service_waiter, daemon=True)
+            thr.start()
+        self._last_orientation_request_time = 0.0
+        self._orientation_request_rate = 10.0
+        self._last_requested_angle = None
+        self._last_rx_log_time = 0.0
+        self._orientation_target = None
+        self.declare_parameter("orientation_kp", 3.0)
+        self.declare_parameter("orientation_min_speed", 0.8)
+        self.declare_parameter("orientation_max_accel", 20.0)
+        self.declare_parameter("orientation_tolerance", 0.03)
+        self._orientation_kp = float(self.get_parameter("orientation_kp").value)
+        self._orientation_min_speed = float(self.get_parameter("orientation_min_speed").value)
+        self._orientation_max_accel = float(self.get_parameter("orientation_max_accel").value)
+        self._orientation_tolerance = float(self.get_parameter("orientation_tolerance").value)
+        self._last_orientation_debug_time = 0.0
+        self.declare_parameter("right_stick_invert_x", False)
+        self.declare_parameter("right_stick_invert_y", False)
+        self._rs_invert_x = bool(self.get_parameter("right_stick_invert_x").value)
+        self._rs_invert_y = bool(self.get_parameter("right_stick_invert_y").value)
+        self.declare_parameter("orientation_stick_activate", 0.25)
+        self.declare_parameter("orientation_stick_deactivate", 0.10)
+        self.declare_parameter("orientation_update_angle_thresh", 0.05)
+        self._orientation_stick_activate = float(self.get_parameter("orientation_stick_activate").value)
+        self._orientation_stick_deactivate = float(self.get_parameter("orientation_stick_deactivate").value)
+        self._orientation_update_angle_thresh = float(self.get_parameter("orientation_update_angle_thresh").value)
+
+    def update_and_publish(self) -> None:
+        """Integra acelerações desejadas para atualizar velocidades e publica o comando."""
+        global desired_acc_x, desired_acc_y, desired_acc_t, robot_theta
+
+        now = time()
+        dt = max(1e-6, now - self._last_time)
+        self._last_time = now
+        def axis_value_or_zero(axis_key):
+            pos = self._axis_pos.get(axis_key, 0.0)
+            last = self._axis_last_time.get(axis_key, 0.0)
+            age = now - last
+            if abs(pos) > 1e-4:
+                if age > self.dead_input_timeout_long:
+                    return 0.0
+                return pos
+            return 0.0
+
+        jx = -self._axis_pos.get("ry", 0.0)
+        jy = -self._axis_pos.get("rx", 0.0)
+        if getattr(self, "_rs_invert_x", False):
+            jx = -jx
+        if getattr(self, "_rs_invert_y", False):
+            jy = -jy
+        joy_mag = math.hypot(jx, jy)
+        if (now - self._last_rx_log_time) > 0.5 and (abs(jx) > 1e-3 or abs(jy) > 1e-3):
+            self._last_rx_log_time = now
+        if joy_mag > 0.5:
+            target_angle = math.atan2(jy, jx)
+            self._orientation_target = float(target_angle)
+            # debug logging removed
+
+            if self._set_orientation_client is not None:
+                now_req = now
+                min_dt = 1.0 / max(1.0, self._orientation_request_rate)
+                angle_changed = (
+                    self._last_requested_angle is None or
+                    abs(((target_angle - self._last_requested_angle + math.pi) % (2 * math.pi)) - math.pi) > 0.05
+                )
+                if (now_req - self._last_orientation_request_time) >= min_dt and angle_changed:
+                    if not self._orientation_service_ready:
+                        if not self._orientation_service_warned:
+                            self._orientation_service_warned = True
+                        raise RuntimeError("set_orientation service missing")
+                    req = SetOrientation.Request()
+                    req.robot_id = int(self.robot_id)
+                    req.orientation = float(target_angle)
+                    self._set_orientation_client.call_async(req)
+                    self._last_orientation_request_time = now_req
+                    self._last_requested_angle = target_angle
+
+        ax_pos = axis_value_or_zero("x")
+        ay_pos = axis_value_or_zero("y")
+        at_pos = axis_value_or_zero("t")
+
+        if joy_mag > 0.2:
+            at_pos = 0.0
+            self._axis_pos["t"] = 0.0
+            self._axis_last_time["t"] = now
+
+        ax = max(-self.max_acceleration, min(self.max_acceleration, ax_pos * self.max_acceleration))
+        ay = max(-self.max_acceleration, min(self.max_acceleration, ay_pos * self.max_acceleration))
+        at = max(-self.max_angular_acceleration, min(self.max_angular_acceleration, at_pos * self.max_angular_acceleration))
+
+        desired_acc_x = ax
+        desired_acc_y = ay
+        desired_acc_t = at
+
+        self.vx += ax * dt
+        self.vy += ay * dt
+        self.vt += at * dt
+
+        def move_towards(value, target, max_delta):
+            diff = target - value
+            if abs(diff) <= max_delta:
+                return target
+            return value + (max_delta if diff > 0 else -max_delta)
+
+        if abs(ax_pos) < 1e-3:
+            self.vx = move_towards(self.vx, 0.0, self.decel * dt)
+        if abs(ay_pos) < 1e-3:
+            self.vy = move_towards(self.vy, 0.0, self.decel * dt)
+        if abs(at_pos) < 1e-3:
+            self.vt = move_towards(self.vt, 0.0, self.angular_decel * dt)
+
+        self.vx = max(-self.max_velocity, min(self.max_velocity, self.vx))
+        self.vy = max(-self.max_velocity, min(self.max_velocity, self.vy))
+        self.vt = max(-self.max_angular_velocity, min(self.max_angular_velocity, self.vt))
+
+        def _normalize_angle(a: float) -> float:
+            return ((a + math.pi) % (2 * math.pi)) - math.pi
+
+        if self._orientation_target is not None:
+            self._orientation_kp = float(self.get_parameter("orientation_kp").value)
+            self._orientation_min_speed = float(self.get_parameter("orientation_min_speed").value)
+            self._orientation_tolerance = float(self.get_parameter("orientation_tolerance").value)
+
+            err = _normalize_angle(self._orientation_target - robot_theta)
+            if abs(err) <= self._orientation_tolerance:
+                self.vt = 0.0
+                self._orientation_target = None
+            else:
+                desired_vt = self._orientation_kp * err
+                if abs(desired_vt) < self._orientation_min_speed:
+                    desired_vt = math.copysign(self._orientation_min_speed, desired_vt)
+                desired_vt = max(-self.max_angular_velocity, min(self.max_angular_velocity, desired_vt))
+                self._orientation_max_accel = float(self.get_parameter("orientation_max_accel").value)
+                max_delta = max(1e-6, self._orientation_max_accel * dt)
+                self.vt = move_towards(self.vt, desired_vt, max_delta)
+                if (now - self._last_orientation_debug_time) > 0.25:
+                    self._last_orientation_debug_time = now
+
+        theta = robot_theta
+        cos_t = math.cos(theta)
+        sin_t = math.sin(theta)
+        vx_r = cos_t * self.vx + sin_t * self.vy
+        vy_r = -sin_t * self.vx + cos_t * self.vy
+
         robot_command = RobotCommand()
         robot_command.robot_id = 0
-        robot_command.linear_velocity_x = vx
-        robot_command.linear_velocity_y = vy
-        robot_command.angular_velocity = vt
+        robot_command.linear_velocity_x = float(vx_r)
+        robot_command.linear_velocity_y = float(vy_r)
+        robot_command.angular_velocity = float(self.vt)
         robot_command.kick = 0.0
+
         command = TeamCommand()
         command.robots.append(robot_command)
 
-        return command
+        now = time()
+        if now - self._last_log_time >= 1.0:
+            self._last_log_time = now
+        self.command_publisher.publish(command)
 
-    def calculate_velocity(self, key, is_negative_key):
-        if key in [
-            "q",
-            "e",
-        ]:
-            max_velocity = 6.0
-        else:
-            max_velocity = self.max_velocity
-        current_time = time()
-        if key in self.key_press_times:
-            elapsed_time = current_time - self.key_press_times[key]
-            self.velocities[key] = min(
-                max_velocity, elapsed_time * self.acceleration_rate
-            )
-            if is_negative_key:
-                self.velocities[key] *= -1
-        else:
-            # Apply decay
-            if self.velocities[key] > 0:
-                self.velocities[key] = max(0.0, self.velocities[key] - self.decay_rate)
-            elif self.velocities[key] < 0:
-                self.velocities[key] = min(0.0, self.velocities[key] + self.decay_rate)
-        return self.velocities[key]
+    def _evdev_thread(self, path: str) -> None:
+        """Reader thread using python-evdev directly on the given device path."""
+        global desired_acc_x, desired_acc_y, desired_acc_t
+        dev = InputDevice(path)
 
-    def on_press(self, key):
-        try:
-            if (
-                key.char in ["w", "a", "s", "d", "q", "e"]
-                and key.char not in self.key_press_times
-            ):
-                self.key_press_times[key.char] = time()
-        except AttributeError:
-            pass
+        def norm_ev(code, value):
+            ai = dev.absinfo(code)
+            minv = getattr(ai, 'min', -32768)
+            maxv = getattr(ai, 'max', 32767)
+            if maxv == minv:
+                return 0.0
+            if minv < 0:
+                denom = max(abs(minv), abs(maxv))
+                return max(-1.0, min(1.0, float(value) / float(denom)))
+            else:
+                return max(-1.0, min(1.0, (2.0 * (value - minv) / (maxv - minv)) - 1.0))
 
-    def on_release(self, key):
-        try:
-            if key.char in self.key_press_times:
-                del self.key_press_times[key.char]
-        except AttributeError:
-            pass
+        for event in dev.read_loop():
+            if event.type != ecodes.EV_ABS:
+                continue
+            code = event.code
+            val = event.value
 
+            if not self._got_gamepad_event:
+                self._got_gamepad_event = True
+            if code not in self._seen_codes:
+                self._seen_codes.add(code)
+
+            dz = 0.12
+            now = time()
+            if code not in self._evdev_code_map:
+                if code == ecodes.ABS_X:
+                    self._evdev_code_map[code] = "x"
+                elif code == ecodes.ABS_Y:
+                    self._evdev_code_map[code] = "y"
+                elif code == ecodes.ABS_RX:
+                    self._evdev_code_map[code] = "rx"
+                elif code == ecodes.ABS_RY:
+                    self._evdev_code_map[code] = "ry"
+                else:
+                    mapped_vals = set(self._evdev_code_map.values())
+                    if "rx" not in mapped_vals:
+                        self._evdev_code_map[code] = "rx"
+                    elif "ry" not in mapped_vals:
+                        self._evdev_code_map[code] = "ry"
+                    else:
+                        self._evdev_code_map[code] = None
+            axis_key = self._evdev_code_map.get(code)
+            if axis_key == "x":
+                v = norm_ev(code, val)
+                self._axis_pos["x"] = 0.0 if abs(v) < dz else v
+                self._axis_last_time["x"] = now
+            elif axis_key == "y":
+                v = -norm_ev(code, val)
+                self._axis_pos["y"] = 0.0 if abs(v) < dz else v
+                self._axis_last_time["y"] = now
+            elif axis_key == "rx":
+                v = norm_ev(code, val)
+                self._axis_pos["rx"] = 0.0 if abs(v) < dz else v
+                self._axis_last_time["rx"] = now
+            elif axis_key == "ry":
+                v = -norm_ev(code, val)
+                self._axis_pos["ry"] = 0.0 if abs(v) < dz else v
+                self._axis_last_time["ry"] = now
+            else:
+                if code not in self._seen_codes:
+                    self._seen_codes.add(code)
+
+    # pygame backend removed (not used in simplified configuration)
+
+    def _joy_callback(self, msg: Joy) -> None:
+        """Fallback callback to read joystick from sensor_msgs/Joy topics.
+
+        axes layout can vary; mapping below is a reasonable default for Xbox-like controllers.
+        """
+        global desired_acc_x, desired_acc_y, desired_acc_t
+
+        axes = msg.axes
+        lx = axes[0] if len(axes) > 0 else 0.0
+        ly = axes[1] if len(axes) > 1 else 0.0
+        rx = axes[3] if len(axes) > 3 else (axes[2] if len(axes) > 2 else 0.0)
+        ry = axes[4] if len(axes) > 4 else (axes[3] if len(axes) > 3 else (axes[2] if len(axes) > 2 else 0.0))
+
+        now = time()
+        self._axis_pos["x"] = float(lx)
+        self._axis_last_time["x"] = now
+        self._axis_pos["y"] = -float(ly)
+        self._axis_last_time["y"] = now
+        self._axis_pos["rx"] = float(rx)
+        self._axis_last_time["rx"] = now
+        self._axis_pos["ry"] = -float(ry)
+        self._axis_last_time["ry"] = now
+
+        # debug logging removed
+
+    def _vision_callback(self, msg: VisionMessage) -> None:
+        """Recebe o VisionMessage e atualiza a orientação do robô controlado (robot_id)."""
+        global robot_theta
+        rid = self.robot_id
+
+        for r in msg.blue_robots:
+            if int(r.id) == rid:
+                robot_theta = float(r.orientation)
+                return
+        for r in msg.yellow_robots:
+            if int(r.id) == rid:
+                robot_theta = float(r.orientation)
+                return
+
+    def _orientation_service_waiter(self) -> None:
+        """Background thread to wait for the set_orientation service to appear.
+
+        This avoids blocking the main update loop and lets us know when it's safe
+        to call the service.
+        """
+        if self._set_orientation_client is None:
+            return
+        while rclpy.ok() and not self._orientation_service_ready:
+            ok = self._set_orientation_client.wait_for_service(timeout_sec=1.0)
+            if ok:
+                self._orientation_service_ready = True
+                break
 
 def main():
     rclpy.init()
     manual_command = ManualCommand()
-    thread = Thread(target=rclpy.spin, args=(manual_command,))
+    thread = Thread(target=rclpy.spin, args=(manual_command,), daemon=True)
     thread.start()
-    listener = keyboard.Listener(
-        on_press=manual_command.on_press, on_release=manual_command.on_release
-    )
-    listener.start()
-    listener.join()
+
+    while rclpy.ok():
+        sleep(0.1)
+
     rclpy.shutdown()
 
 

--- a/src/manual_command/manual_command/manual.py
+++ b/src/manual_command/manual_command/manual.py
@@ -32,8 +32,8 @@ class ManualCommand(Node):
     def __init__(self) -> None:
         super().__init__("manual_command")
 
-        self.declare_parameter("robot_id", 0)
-        self.robot_id = int(self.get_parameter("robot_id").value)
+        self.declare_parameter("robot_id", 1)
+        self.robot_id = 1
         self.command_publisher = self.create_publisher(TeamCommand, "commandTopic", 10)
         self.create_timer(1.0 / 60.0, self.update_and_publish)
 
@@ -44,9 +44,9 @@ class ManualCommand(Node):
         self.vt = 0.0
 
         self.max_velocity = 1.5
-        self.max_angular_velocity = 6.0
-        self.max_acceleration = 3.0
-        self.max_angular_acceleration = 6.0
+        self.max_angular_velocity = 1.5
+        self.max_acceleration = 1
+        self.max_angular_acceleration = 3.0 
 
         self._last_time = time()
         self._last_log_time = time()
@@ -94,7 +94,7 @@ class ManualCommand(Node):
         self._last_requested_angle = None
         self._last_rx_log_time = 0.0
         self._orientation_target = None
-        self.declare_parameter("orientation_kp", 3.0)
+        self.declare_parameter("orientation_kp", 1.0)
         self.declare_parameter("orientation_min_speed", 0.8)
         self.declare_parameter("orientation_max_accel", 20.0)
         self.declare_parameter("orientation_tolerance", 0.03)
@@ -105,8 +105,6 @@ class ManualCommand(Node):
         self._last_orientation_debug_time = 0.0
         self.declare_parameter("right_stick_invert_x", False)
         self.declare_parameter("right_stick_invert_y", False)
-        self._rs_invert_x = bool(self.get_parameter("right_stick_invert_x").value)
-        self._rs_invert_y = bool(self.get_parameter("right_stick_invert_y").value)
         self.declare_parameter("orientation_stick_activate", 0.25)
         self.declare_parameter("orientation_stick_deactivate", 0.10)
         self.declare_parameter("orientation_update_angle_thresh", 0.05)
@@ -133,14 +131,10 @@ class ManualCommand(Node):
 
         jx = -self._axis_pos.get("ry", 0.0)
         jy = -self._axis_pos.get("rx", 0.0)
-        if getattr(self, "_rs_invert_x", False):
-            jx = -jx
-        if getattr(self, "_rs_invert_y", False):
-            jy = -jy
         joy_mag = math.hypot(jx, jy)
         if (now - self._last_rx_log_time) > 0.5 and (abs(jx) > 1e-3 or abs(jy) > 1e-3):
             self._last_rx_log_time = now
-        if joy_mag > 0.5:
+        if joy_mag > 1.0:
             target_angle = math.atan2(jy, jx)
             self._orientation_target = float(target_angle)
             # debug logging removed
@@ -232,7 +226,7 @@ class ManualCommand(Node):
         vy_r = -sin_t * self.vx + cos_t * self.vy
 
         robot_command = RobotCommand()
-        robot_command.robot_id = 0
+        robot_command.robot_id = 1
         robot_command.linear_velocity_x = float(vx_r)
         robot_command.linear_velocity_y = float(vy_r)
         robot_command.angular_velocity = float(self.vt)

--- a/src/manual_command/setup.py
+++ b/src/manual_command/setup.py
@@ -1,5 +1,6 @@
 from setuptools import find_packages, setup
 
+
 package_name = "manual_command"
 
 setup(
@@ -10,7 +11,7 @@ setup(
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
         ("share/" + package_name, ["package.xml"]),
     ],
-    install_requires=["setuptools"],
+    install_requires=["setuptools", "evdev"],
     zip_safe=True,
     maintainer="allan",
     maintainer_email="allan.menchik@hotmail.com",

--- a/src/new_movement/new_movement/utilities/trajectory_generator/TrajGenerator.py
+++ b/src/new_movement/new_movement/utilities/trajectory_generator/TrajGenerator.py
@@ -28,7 +28,7 @@ class TrajectoryGenerator:
         # Is close enough to accelerate
         if(curState.position.distance(tarState.position) < NEAR_THRESHOLD):
             self.update_constrainsts(MoveConstraints(
-                DEFAULT_VELOCITY_CONSTRAINST, NEAR_ACCELERATION_CONSTRAINST
+                DEFAULT_VELOCITY_CONSTRAINST, DEFAULT_ACCELERATION_CONSTRAINST
             ))
         else:
             self.update_constrainsts(MoveConstraints(

--- a/src/strategy/strategy/tatics/running.py
+++ b/src/strategy/strategy/tatics/running.py
@@ -142,7 +142,7 @@ class Atack:
 
         robot_command.field_border = True
         robot_command.ball = True
-        robot_command.ally_ids = [0]
+        robot_command.ally_ids = [0, 1]
         robot_command.enemy_ids = self._enemy_is_near_ball()
         robot_command.penalty_area = True
         robot_command.deactivate_kick()
@@ -172,7 +172,7 @@ class Atack:
 
         robot_command.ball = False
         robot_command.field_border = True
-        robot_command.ally_ids = [0]
+        robot_command.ally_ids = [0, 1]
         robot_command.enemy_ids = self._enemy_is_near_ball()
         robot_command.penalty_area = True
 

--- a/src/strategy/strategy/tatics/stop.py
+++ b/src/strategy/strategy/tatics/stop.py
@@ -91,8 +91,8 @@ class goAwayFromBall:
 
             robot_command = self.skills_factory.move_with_angle(
                 robot_id=rid,
-                target_x=target.x,
-                target_y=target.y,
+                target_x=2000,
+                target_y=1400,
                 angle=angle,
             )
 

--- a/src/vision/vision/vision_node.py
+++ b/src/vision/vision/vision_node.py
@@ -23,9 +23,9 @@ class Vision(Node):
         # Parameters settings.
         self.declare_parameter("ip", "224.5.23.2")
         # Visão real
-        # self.declare_parameter("port", 10006)
+        self.declare_parameter("port", 10006)
         # Grsim
-        self.declare_parameter('port', 10020)
+        # self.declare_parameter('port', 10020)
         self.declare_parameter("verbose", False)
         # Optional local interface IP to bind/join multicast (e.g., 192.168.0.10). If empty uses INADDR_ANY.
         self.declare_parameter("interface_ip", "")


### PR DESCRIPTION
This pull request introduces several changes across launch configurations, control parameters, dependencies, and strategy logic. The main themes are updates to node launching for both real and simulation environments, tuning of controller parameters, dependency additions, and strategy behavior adjustments.

**Launch configuration updates:**

* In `launch/real_one.py`, the `strategyNode` launch is commented out, and a new node for `strategy_command_gui` (`strategy_gui`) is added to the launch sequence. [[1]](diffhunk://#diff-cf37c5075c44cde012a97688ee6edbc3adbf4185ec37b15d0406052449ab1867L25-R28) [[2]](diffhunk://#diff-cf37c5075c44cde012a97688ee6edbc3adbf4185ec37b15d0406052449ab1867L41-R45)
* In `launch/sim_one.py`, several nodes (`new_movement`, `strategyNode`, `gui_interpreter`, and `referee_node`) are commented out, while new nodes for `manual_command` (`manual_node`) and `hardware_messenger` are added.

**Controller and movement logic tuning:**

* In `src/control/control/control.py`, the orientation controller's parameters are updated for higher responsiveness (`kp=1`, `max_output=2`).
* In `src/new_movement/new_movement/utilities/trajectory_generator/TrajGenerator.py`, the acceleration constraint for near-target movement uses the default value instead of a separate near value.

**Dependency management:**

* Both `src/grsim_messenger/setup.py` and `src/manual_command/setup.py` now include `evdev` as an install requirement, supporting device event handling. [[1]](diffhunk://#diff-6a9b5edab5496c190b01acda4c1ac80899f421a702451e4001664b5acdc2304fL14-R14) [[2]](diffhunk://#diff-5f1f96f91809e63d24a7c495f39d20645e40d9fbfc2ae78e3e8383b612b3f748L13-R14)

**Strategy logic adjustments:**

* In `src/strategy/strategy/tatics/running.py`, the list of ally IDs for ball-related commands now includes both robots 0 and 1 instead of just 0, broadening the scope of ally consideration. [[1]](diffhunk://#diff-ae65f2e608e05ff5855536d22103e4017c7a91eef3577a841cc4ce580fbdaf24L145-R145) [[2]](diffhunk://#diff-ae65f2e608e05ff5855536d22103e4017c7a91eef3577a841cc4ce580fbdaf24L175-R175)
* In `src/strategy/strategy/tatics/stop.py`, the target coordinates for the stop tactic are hardcoded to (2000, 1400) instead of using the target object's coordinates.

**Vision node parameter selection:**

* In `src/vision/vision/vision_node.py`, the port parameter for real vision is now active (10006), while the Grsim port (10020) is commented out, indicating a focus on real vision setup.