### PR TITLE
deleting unused messages from system_interfaces

### DIFF
--- a/src/system_interfaces/msg/Command.msg
+++ b/src/system_interfaces/msg/Command.msg
@@ -1,3 +1,0 @@
-ObjectID id
-Movement movement
-bool kick

--- a/src/system_interfaces/msg/Communication.msg
+++ b/src/system_interfaces/msg/Communication.msg
@@ -1,1 +1,0 @@
-Command[] commands

--- a/src/system_interfaces/msg/Infos.msg
+++ b/src/system_interfaces/msg/Infos.msg
@@ -1,2 +1,0 @@
-ObjectID id
-bool is_alive

--- a/src/system_interfaces/msg/Movement.msg
+++ b/src/system_interfaces/msg/Movement.msg
@@ -1,3 +1,0 @@
-float32 velocity_x
-float32 velocity_y
-float32 orientation


### PR DESCRIPTION
This pull request removes several message definitions from the `system_interfaces` package, likely as part of a refactor or cleanup of unused or obsolete messages. The changes affect the core message types used for commands, communication, information, and movement in the system.

Removed message fields and types:

**Command and related messages:**
* Removed all fields (`id`, `movement`, `kick`) from the `Command` message, effectively deleting its content.
* Removed the `commands` array from the `Communication` message.

**Information and movement messages:**
* Removed all fields (`id`, `is_alive`) from the `Infos` message, effectively deleting its content.
* Removed all fields (`velocity_x`, `velocity_y`, `orientation`) from the `Movement` message, effectively deleting its content.