### PR TITLE
Improve CLI and developer experience

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// .devcontainer/devcontainer.json
+{
+  "name": "ssl-VICE",
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "service": "ssl-vice",
+  "workspaceFolder": "/root/ssl-VICE",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff"
+      ],
+      "settings": {
+        "python.analysis.extraPaths": [
+          "/opt/ros/humble/lib/python3.10/dist-packages",
+          "/root/ssl-VICE/install/system_interfaces/local/lib/python3.10/dist-packages"
+        ],
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.formatOnSave": true,
+          "editor.codeActionsOnSave": {
+            "source.fixAll.ruff": "explicit",
+            "source.organizeImports.ruff": "explicit"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .vscode/
 .venv/
 
-.devcontainer/
 build/
 install/
 log/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ install/
 log/
 
 teste.*
+
+.vice_last_launch

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3-colcon-common-extensions \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir --upgrade pip setuptools==58.2.0 wheel packaging \
-  protobuf==3.20.* flask flask-socketio pyserial numpy
+RUN pip install --no-cache-dir --upgrade pip setuptools==58.2.0 wheel packaging
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
 SHELL ["/bin/bash", "-c"]
 RUN echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,15 @@
-# docker/Dockerfile.dev
-FROM ros:humble
+FROM ros:humble-ros-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install common tools + colcon + Python deps
-RUN apt-get update && apt-get install -y \
-    python3-pip \
-    python3-colcon-common-extensions \
-    iproute2 \
-    net-tools \
-    iputils-ping \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  python3-pip \
+  python3-colcon-common-extensions \
+  && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip setuptools==58.2.0 wheel packaging scikit-build protobuf==3.20.* flask flask-socketio pyserial numpy pytest pytest-mock pytest-cov
+RUN pip install --no-cache-dir --upgrade pip setuptools==58.2.0 wheel packaging \
+  protobuf==3.20.* flask flask-socketio pyserial numpy
 
-# ROS environment automatically sourced
 SHELL ["/bin/bash", "-c"]
 RUN echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
 

--- a/README.md
+++ b/README.md
@@ -48,13 +48,19 @@ echo 'export PATH="<caminho-para-ssl-VICE>/scripts:$PATH"' >> ~/.bashrc
 
 Comandos disponíveis:
 
-| Comando       | Descrição                                      |
-| ------------- | ---------------------------------------------- |
-| `vice build`  | Compila o workspace ROS2                       |
-| `vice launch` | Seleciona e executa um launch file             |
-| `vice reload` | Recompila e relança o último launch file usado |
-| `vice attach` | Abre um shell interativo no container          |
-| `vice topics` | Lista e escuta tópicos ROS2                    |
+| Comando                | Descrição                                      |
+| ---------------------- | ---------------------------------------------- |
+| `vice build`           | Compila o workspace ROS2                       |
+| `vice launch`          | Seleciona e executa um launch file             |
+| `vice reload`          | Recompila e relança o último launch file usado |
+| `vice run <pkg> <node>`| Executa um node individual (menu interativo se sem args) |
+| `vice attach`          | Abre um shell interativo no container          |
+| `vice topics`          | Lista e escuta tópicos ROS2                    |
+| `vice start`           | Inicia o container                             |
+| `vice stop`            | Para o container                               |
+| `vice restart`         | Reinicia o container                           |
+| `vice destroy`         | Remove o container e a imagem completamente    |
+| `vice clean`           | Remove build/, install/, log/                  |
 
 Fluxo de desenvolvimento:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <div align="center">
 <a href="https://quackfy.vercel.app/">
 <img height="100" src="https://ararabots-ufms.github.io/img/arara_no_bg.png" alt="Arara">
@@ -12,14 +11,13 @@
 
 ## Configuração de Ambiente
 
-<!-- Para aprender como instalar os programas e pacotes necessários, confira o [README dos Requisitos](./requirements/README.MD) -->
-
 **Importante:** Além do repositório `ssl-VICE`, é necessário clonar os repositórios `ssl-gui` e `ssl-game-controller` na **mesma pasta** para que o sistema funcione corretamente.
 
 Então é recomendado criar uma pasta "ararabots" e dentro clonar os respectivos repositórios de desenvolvimento
 Se for clonado repositórios posteriores clonar dentro da pasta.
 
 Com HTTP:
+
 ```bash
 mkdir ararabots
 cd ararabots
@@ -29,6 +27,7 @@ git clone https://github.com/RoboCup-SSL/ssl-game-controller.git # com HTTP
 ```
 
 Com SSH:
+
 ```bash
 mkdir ararabots
 cd ararabots
@@ -37,28 +36,53 @@ git clone git@github.com:Ararabots-UFMS/ssl-VICE.git
 git clone git@github.com:RoboCup-SSL/ssl-game-controller.git
 ```
 
-
 ## Execução
-Em seguida, execute dentro da pasta do `ssl-VICE`:
+
+### Usando o Vice CLI (recomendado para desenvolvimento)
+
+Adicione o diretório `scripts/` ao seu PATH:
+
+```bash
+echo 'export PATH="<caminho-para-ssl-VICE>/scripts:$PATH"' >> ~/.bashrc
+```
+
+Comandos disponíveis:
+
+| Comando       | Descrição                                      |
+| ------------- | ---------------------------------------------- |
+| `vice build`  | Compila o workspace ROS2                       |
+| `vice launch` | Seleciona e executa um launch file             |
+| `vice reload` | Recompila e relança o último launch file usado |
+| `vice attach` | Abre um shell interativo no container          |
+| `vice topics` | Lista e escuta tópicos ROS2                    |
+
+Fluxo de desenvolvimento:
+
+1. Edite o código no host (o repositório é montado no container via volume).
+2. `Ctrl+C` no terminal do `vice launch` para encerrar os nodes.
+3. `vice reload` para recompilar e relançar automaticamente.
+
+### Usando Docker Compose
 
 ```bash
 docker-compose up --build
 ```
-Se não for sua primeira execução rode sem o *--build*
+
+Se não for sua primeira execução rode sem o _--build_
 
 ```bash
 docker-compose up
 ```
 
 Após isso, dois serviços serão criados:
+
 - `ssl-vice`
 - `ssl-gui`
 
 A interface gráfica (GUI) estará disponível em: [http://localhost:5173](http://localhost:5173)
 
+## Até agora temos o `ssl-VICE` e o `ssl-GUI` rodando.
 
-Até agora temos o `ssl-VICE` e o `ssl-GUI` rodando.
----
 Para escutar tópicos específicos do ROS2:
 
 Entre no container `ssl-vice`:
@@ -68,30 +92,30 @@ docker exec -it ssl-vice bash
 source /root/ssl-VICE/install/setup.bash
 ```
 
-E para listar e escutar tópicos, use:
+Ou use o Vice CLI:
 
 ```bash
-ros2 topic list          # lista todos os tópicos disponíveis
-ros2 topic echo /refereeTopic  # escuta um tópico de exemplo
+vice topics
 ```
 
-Agora vamos rodar as aplicações externas
----
+## Agora vamos rodar as aplicações externas
+
 Para rodar o `ssl-game-controller`.
+
 ```bash
 cd ssl-game-controller
 ```
 
 Dentro da pasta do `ssl-game-controller`:
+
 ```bash
 docker compose up --build ssl-game-controller
 ```
 
-
-Agora vamos instalar o `grSim` e o `ssl-vision-client`
----
+## Agora vamos instalar o `grSim` e o `ssl-vision-client`
 
 Com HTTP:
+
 ```bash
 cd ararabots
 git clone https://github.com/RoboCup-SSL/grSim.git
@@ -99,6 +123,7 @@ git clone https://github.com/RoboCup-SSL/ssl-vision.git
 ```
 
 Com SSH:
+
 ```bash
 cd ararabots
 git clone git@github.com:RoboCup-SSL/grSim.git
@@ -111,20 +136,12 @@ Agora entre na pasta do `grSim` e siga as instruções de instalação por lá.
 
 Faça a mesma coisa com o `ssl-vision`.
 
---- 
-## Extras:
+**Usuários de Arch Linux:** Consulte o guia [Configuração no Arch Linux](docs/archlinux-setup.md) para instruções específicas, incluindo instalação do grSim via AUR e correções para Wayland.
 
-### Análise de Código com Ruff no VSCode
-- Ruff é uma ferramenta rápida e eficiente para linting (análise de estilo) e formatação de código Python.
-- Este projeto já inclui um arquivo ruff.toml com as configurações necessárias.
+---
 
-### Como usar o Ruff no VSCode
-- Instale a extensão oficial do Ruff:
-    - “Ruff” na aba de extensões do VSCode e instale a extensão de Charles Marsh.
+## Extras
 
-### Correção automática:
-Use o atalho padrão (Ctrl + Shift + P) e selecione "Ruff: Format Document" para formatar um arquivo inteiro.
+- [Configuração do VS Code](docs/vscode-setup.md) — Dev Container, IntelliSense para ROS2, Ruff com auto-format ao salvar
+- [Configuração no Arch Linux](docs/archlinux-setup.md) — grSim via AUR, correções para Wayland
 
-**Linting em tempo real:** 
-- O VSCode irá sublinhar automaticamente os trechos que não seguem os padrões definidos.
-- Passe o mouse sobre os avisos para ver sugestões ou explicações.

--- a/docs/archlinux-setup.md
+++ b/docs/archlinux-setup.md
@@ -1,0 +1,85 @@
+# Configuracao do Ambiente no Arch Linux
+
+Guia de instalacao e configuracao do ssl-VICE e ferramentas externas no Arch Linux.
+
+## Pre-requisitos
+
+### Docker
+
+```bash
+sudo pacman -S docker docker-compose
+sudo systemctl enable --now docker
+sudo usermod -aG docker $USER
+```
+
+Reinicie a sessao (logout/login) para o grupo `docker` ter efeito.
+
+### Vice CLI
+
+Adicione o diretorio `scripts/` ao seu PATH para usar o comando `vice` globalmente:
+
+```bash
+echo 'export PATH="<caminho-para-ssl-VICE>/scripts:$PATH"' >> ~/.bashrc
+```
+
+Comandos disponiveis:
+
+| Comando       | Descricao                                      |
+| ------------- | ---------------------------------------------- |
+| `vice build`  | Compila o workspace ROS2                       |
+| `vice launch` | Seleciona e executa um launch file             |
+| `vice reload` | Recompila e relanca o ultimo launch file usado |
+| `vice attach` | Abre um shell interativo no container          |
+| `vice topics` | Lista e escuta topicos ROS2                    |
+
+### Fluxo de desenvolvimento
+
+1. Edite o codigo no host (o repositorio e montado no container via volume).
+2. `Ctrl+C` no terminal do `vice launch` para encerrar os nodes.
+3. `vice reload` para recompilar e relancar automaticamente.
+
+## grSim
+
+### Instalacao via AUR
+
+```bash
+yay -S grsim-git
+```
+
+Se a build falhar com erro de `cmake_minimum_required` no `vartypes`, use:
+
+```bash
+CMAKE_POLICY_VERSION_MINIMUM=3.5 yay -S grsim-git
+```
+
+### Problemas de renderizacao no Wayland (Hyprland, Sway, etc.)
+
+O menu lateral do grSim pode nao atualizar corretamente em compositors Wayland. Para corrigir, force o uso do XWayland:
+
+```bash
+QT_QPA_PLATFORM=xcb grSim
+```
+
+Para nao precisar digitar toda vez, crie um alias:
+
+**Bash:**
+
+```bash
+echo 'alias grsim="QT_QPA_PLATFORM=xcb grSim -style Fusion"' >> ~/.bashrc
+```
+
+## ssl-game-controller
+
+```bash
+cd ararabots/ssl-game-controller
+docker compose up --build ssl-game-controller
+```
+
+## ssl-vision
+
+Siga as instrucoes de instalacao no repositorio:
+
+```bash
+cd ararabots
+git clone https://github.com/RoboCup-SSL/ssl-vision.git
+```

--- a/docs/archlinux-setup.md
+++ b/docs/archlinux-setup.md
@@ -24,13 +24,19 @@ echo 'export PATH="<caminho-para-ssl-VICE>/scripts:$PATH"' >> ~/.bashrc
 
 Comandos disponiveis:
 
-| Comando       | Descricao                                      |
-| ------------- | ---------------------------------------------- |
-| `vice build`  | Compila o workspace ROS2                       |
-| `vice launch` | Seleciona e executa um launch file             |
-| `vice reload` | Recompila e relanca o ultimo launch file usado |
-| `vice attach` | Abre um shell interativo no container          |
-| `vice topics` | Lista e escuta topicos ROS2                    |
+| Comando                | Descricao                                      |
+| ---------------------- | ---------------------------------------------- |
+| `vice build`           | Compila o workspace ROS2                       |
+| `vice launch`          | Seleciona e executa um launch file             |
+| `vice reload`          | Recompila e relanca o ultimo launch file usado |
+| `vice run <pkg> <node>`| Executa um node individual (menu interativo se sem args) |
+| `vice attach`          | Abre um shell interativo no container          |
+| `vice topics`          | Lista e escuta topicos ROS2                    |
+| `vice start`           | Inicia o container                             |
+| `vice stop`            | Para o container                               |
+| `vice restart`         | Reinicia o container                           |
+| `vice destroy`         | Remove o container e a imagem completamente    |
+| `vice clean`           | Remove build/, install/, log/                  |
 
 ### Fluxo de desenvolvimento
 

--- a/docs/vscode-setup.md
+++ b/docs/vscode-setup.md
@@ -1,0 +1,56 @@
+# Configuracao do VS Code
+
+## Dev Container (IntelliSense para ROS2)
+
+O projeto inclui uma configuracao de Dev Container em `.devcontainer/devcontainer.json` que configura o VS Code para trabalhar dentro do container Docker com IntelliSense completo.
+
+### Como usar
+
+1. Instale a extensao [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) no VS Code.
+2. Abra o projeto no VS Code.
+3. Quando aparecer a notificacao "Reopen in Container", clique nela. Ou use `Ctrl+Shift+P` > "Dev Containers: Reopen in Container".
+4. O VS Code vai conectar no container `ssl-vice` com Python e Pylance configurados.
+
+### O que ja vem configurado
+
+- **Pylance** com paths para pacotes ROS2 (`rclpy`, `std_srvs`, etc.)
+- **system_interfaces** (mensagens e servicos gerados) reconhecidos pelo IntelliSense
+- Extensoes Python e Pylance instaladas automaticamente no container
+
+### Observacoes
+
+- E necessario ter feito `vice build` pelo menos uma vez antes de abrir o Dev Container, para que as mensagens em `install/system_interfaces/` existam.
+- Erros de tipo em classes protobuf (ex: `grSim_Robot_Command`) sao esperados — protobuf gera atributos dinamicamente e o Pylance nao consegue resolve-los estaticamente.
+
+## Ruff (Linting e Formatacao)
+
+O projeto usa [Ruff](https://docs.astral.sh/ruff/) para linting e formatacao de codigo Python. As regras estao definidas em `ruff.toml` na raiz do projeto.
+
+### Instalacao
+
+Instale a extensao [Ruff](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff) no VS Code (por Charlie Marsh).
+
+### Formatacao automatica ao salvar
+
+Para configurar o Ruff como formatador padrao com auto-format ao salvar, adicione ao seu `settings.json` do VS Code (`Ctrl+Shift+P` > "Preferences: Open User Settings (JSON)"):
+
+```json
+"[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.ruff": "explicit",
+        "source.organizeImports.ruff": "explicit"
+    }
+}
+```
+
+Isso vai:
+- Formatar o codigo automaticamente ao salvar
+- Corrigir problemas de lint auto-corrigiveis
+- Organizar imports automaticamente
+
+### Uso manual
+
+- `Ctrl+Shift+P` > "Ruff: Format Document" para formatar um arquivo
+- Problemas de lint aparecem sublinhados automaticamente no editor

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 flask
 flask-socketio
 pyserial
-protobuf
+protobuf==3.20.*
 numpy
 pytest
 pytest-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 flask
 flask-socketio
-ruckig
 pyserial
 protobuf
 numpy

--- a/scripts/vice
+++ b/scripts/vice
@@ -11,12 +11,22 @@ CONTAINER_NAME="vice"
 DOCKERFILE_PATH="$PROJECT_ROOT/Dockerfile"
 LAST_LAUNCH_FILE="$PROJECT_ROOT/.vice_last_launch"
 
+# --- Run a command inside the container with ROS + overlay sourced ---
+# Usage: ros_exec [-it] "<command>"
+ros_exec() {
+    local flags=""
+    if [[ "$1" == "-it" ]]; then flags="-it"; shift; fi
+    docker exec $flags $CONTAINER_NAME bash -c \
+        "source /opt/ros/humble/setup.bash && \
+         [ -f /root/ssl-VICE/install/local_setup.bash ] && source /root/ssl-VICE/install/local_setup.bash; \
+         $*"
+}
+
 # --- Tip ---
 if [[ ":$PATH:" != *":$PWD/scripts:"* && ":$PATH:" != *":$PWD/scripts/:"* ]]; then
     echo "!! Add '$PWD/scripts' to your PATH to use 'vice' globally:"
     echo " $ echo 'export PATH=\"$PWD/scripts:\$PATH\"' >> ~/.bashrc"
 fi
-
 
 # --- Build image if not exists ---
 if [[ "$(docker images -q $IMAGE_NAME 2> /dev/null)" == "" ]]; then
@@ -45,21 +55,18 @@ fi
 # --- Parse command ---
 if [[ "$1" == "build" ]]; then
     echo ":: Building ROS2 workspace..."
-    docker exec $CONTAINER_NAME bash -c "source /opt/ros/humble/setup.bash && cd /root/ssl-VICE && colcon build"
+    ros_exec "cd /root/ssl-VICE && colcon build"
     echo "✔ DONE"
 
 elif [[ "$1" == "attach" ]]; then
     echo ":: Opening interactive bash shell..."
-    docker exec -it $CONTAINER_NAME bash -c \
-        "source /opt/ros/humble/setup.bash && \
-         [ -f /root/ssl-VICE/install/local_setup.bash ] && source /root/ssl-VICE/install/local_setup.bash; \
-         exec bash"
+    ros_exec -it "exec bash"
     echo "✔ DONE"
 
 elif [[ "$1" == "launch" ]]; then
     LAUNCH_DIR="$PROJECT_ROOT/launch"
     mapfile -t LAUNCH_FILES < <(find "$LAUNCH_DIR" -maxdepth 1 -type f -name "*.py" -printf "%f\n" | sort)
-    
+
     if [[ ${#LAUNCH_FILES[@]} -eq 0 ]]; then
         echo "X No launch files found in $LAUNCH_DIR"
         exit 1
@@ -70,10 +77,7 @@ elif [[ "$1" == "launch" ]]; then
         if [[ -n "$LAUNCH_FILE" ]]; then
             echo "$LAUNCH_FILE" > "$LAST_LAUNCH_FILE"
             echo ":: Launching $LAUNCH_FILE..."
-            docker exec -it $CONTAINER_NAME bash -c \
-                "source /opt/ros/humble/setup.bash && \
-                 source /root/ssl-VICE/install/local_setup.bash && \
-                 ros2 launch launch/$LAUNCH_FILE"
+            ros_exec -it "ros2 launch launch/$LAUNCH_FILE"
             break
         else
             echo "X Invalid choice. Try again."
@@ -83,25 +87,20 @@ elif [[ "$1" == "launch" ]]; then
 
 elif [[ "$1" == "reload" ]]; then
     echo ":: Rebuilding workspace..."
-    docker exec $CONTAINER_NAME bash -c "source /opt/ros/humble/setup.bash && cd /root/ssl-VICE && colcon build"
+    ros_exec "cd /root/ssl-VICE && colcon build"
     if [[ ! -f "$LAST_LAUNCH_FILE" ]]; then
         echo ":: No previous launch found. Falling back to 'vice launch'..."
         exec "$0" launch
     fi
     LAUNCH_FILE="$(cat "$LAST_LAUNCH_FILE")"
     echo ":: Relaunching $LAUNCH_FILE..."
-    docker exec -it $CONTAINER_NAME bash -c \
-        "source /opt/ros/humble/setup.bash && \
-         source /root/ssl-VICE/install/local_setup.bash && \
-         ros2 launch launch/$LAUNCH_FILE"
+    ros_exec -it "ros2 launch launch/$LAUNCH_FILE"
     echo "✔ DONE"
 
 elif [[ "$1" == "topics" ]]; then
     echo ":: Fetching active ROS 2 topics from container '$CONTAINER_NAME'..."
-    
-    # Get list of topics from inside container
-    mapfile -t TOPICS < <(docker exec $CONTAINER_NAME bash -c \
-        "source /opt/ros/humble/setup.bash && ros2 topic list" 2>/dev/null)
+
+    mapfile -t TOPICS < <(ros_exec "ros2 topic list" 2>/dev/null)
 
     if [[ ${#TOPICS[@]} -eq 0 ]]; then
         echo "X No topics found. Make sure ROS2 nodes are running inside the container."
@@ -113,8 +112,7 @@ elif [[ "$1" == "topics" ]]; then
         if [[ -n "$TOPIC" ]]; then
             echo ":: Listening to topic: $TOPIC"
             echo ":: Press Ctrl+C to stop."
-            docker exec -it $CONTAINER_NAME bash -c \
-                "source /opt/ros/humble/setup.bash && source /root/ssl-VICE/install/local_setup.bash && ros2 topic echo $TOPIC"
+            ros_exec -it "ros2 topic echo $TOPIC"
             break
         else
             echo "X Invalid selection, try again."

--- a/scripts/vice
+++ b/scripts/vice
@@ -49,7 +49,10 @@ if [[ "$1" == "build" ]]; then
 
 elif [[ "$1" == "attach" ]]; then
     echo ":: Opening interactive bash shell..."
-    docker exec -it $CONTAINER_NAME bash
+    docker exec -it $CONTAINER_NAME bash -c \
+        "source /opt/ros/humble/setup.bash && \
+         [ -f /root/ssl-VICE/install/local_setup.bash ] && source /root/ssl-VICE/install/local_setup.bash; \
+         exec bash"
     echo "✔ DONE"
 
 elif [[ "$1" == "launch" ]]; then

--- a/scripts/vice
+++ b/scripts/vice
@@ -68,7 +68,7 @@ elif [[ "$1" == "launch" ]]; then
     select LAUNCH_FILE in "${LAUNCH_FILES[@]}"; do
         if [[ -n "$LAUNCH_FILE" ]]; then
             echo ":: Launching $LAUNCH_FILE..."
-            docker exec $CONTAINER_NAME bash -c \
+            docker exec -it $CONTAINER_NAME bash -c \
                 "source /opt/ros/humble/setup.bash && \
                  source /root/ssl-VICE/install/local_setup.bash && \
                  ros2 launch launch/$LAUNCH_FILE"
@@ -109,6 +109,6 @@ else
     echo "  vice build                 # Build workspace"
     echo "  vice topics                # Echo topics"
     echo "  vice attach                # Open interactive shell"
-    echo "  vice launch		       # Runs launch files"
+    echo "  vice launch                # Runs launch files"
 fi
 

--- a/scripts/vice
+++ b/scripts/vice
@@ -12,7 +12,6 @@ DOCKERFILE_PATH="$PROJECT_ROOT/Dockerfile"
 LAST_LAUNCH_FILE="$PROJECT_ROOT/.vice_last_launch"
 
 # --- Run a command inside the container with ROS + overlay sourced ---
-# Usage: ros_exec [-it] "<command>"
 ros_exec() {
     local flags=""
     if [[ "$1" == "-it" ]]; then flags="-it"; shift; fi
@@ -22,109 +21,212 @@ ros_exec() {
          $*"
 }
 
-# --- Tip ---
-if [[ ":$PATH:" != *":$PWD/scripts:"* && ":$PATH:" != *":$PWD/scripts/:"* ]]; then
-    echo "!! Add '$PWD/scripts' to your PATH to use 'vice' globally:"
-    echo " $ echo 'export PATH=\"$PWD/scripts:\$PATH\"' >> ~/.bashrc"
-fi
-
-# --- Build image if not exists ---
-if [[ "$(docker images -q $IMAGE_NAME 2> /dev/null)" == "" ]]; then
-    echo ":: Docker image '$IMAGE_NAME' not found. Building..."
-    docker build -t $IMAGE_NAME -f "$DOCKERFILE_PATH" "$PROJECT_ROOT"
-else
-    echo "✔  Docker image '$IMAGE_NAME' already exists."
-fi
-
-# --- Start container if not running ---
-if [[ "$(docker ps -q -f name=^${CONTAINER_NAME}$)" == "" ]]; then
-    if [[ "$(docker ps -aq -f name=^${CONTAINER_NAME}$)" != "" ]]; then
-        echo ":: Removing old stopped container '$CONTAINER_NAME'..."
-        docker rm $CONTAINER_NAME > /dev/null
+# --- Ensure image and container are ready ---
+ensure_container() {
+    if [[ ":$PATH:" != *":$PWD/scripts:"* && ":$PATH:" != *":$PWD/scripts/:"* ]]; then
+        echo "!! Add '$PWD/scripts' to your PATH to use 'vice' globally:"
+        echo " $ echo 'export PATH=\"$PWD/scripts:\$PATH\"' >> ~/.bashrc"
     fi
 
-    echo ":: Starting new container '$CONTAINER_NAME'..."
-    docker run -d --name $CONTAINER_NAME \
-        --network host \
-        -v "$PROJECT_ROOT":/root/ssl-VICE \
-        $IMAGE_NAME tail -f /dev/null
-else
-    echo "✔ Container '$CONTAINER_NAME' already running."
-fi
+    if [[ "$(docker images -q $IMAGE_NAME 2> /dev/null)" == "" ]]; then
+        echo ":: Docker image '$IMAGE_NAME' not found. Building..."
+        docker build -t $IMAGE_NAME -f "$DOCKERFILE_PATH" "$PROJECT_ROOT"
+    else
+        echo "✔  Docker image '$IMAGE_NAME' already exists."
+    fi
+
+    if [[ "$(docker ps -q -f name=^${CONTAINER_NAME}$)" == "" ]]; then
+        if [[ "$(docker ps -aq -f name=^${CONTAINER_NAME}$)" != "" ]]; then
+            echo ":: Removing old stopped container '$CONTAINER_NAME'..."
+            docker rm $CONTAINER_NAME > /dev/null
+        fi
+
+        echo ":: Starting new container '$CONTAINER_NAME'..."
+        docker run -d --name $CONTAINER_NAME \
+            --network host \
+            -v "$PROJECT_ROOT":/root/ssl-VICE \
+            $IMAGE_NAME tail -f /dev/null
+    else
+        echo "✔ Container '$CONTAINER_NAME' already running."
+    fi
+}
 
 # --- Parse command ---
-if [[ "$1" == "build" ]]; then
-    echo ":: Building ROS2 workspace..."
-    ros_exec "cd /root/ssl-VICE && colcon build"
-    echo "✔ DONE"
+case "$1" in
+    build)
+        ensure_container
+        echo ":: Building ROS2 workspace..."
+        ros_exec "cd /root/ssl-VICE && colcon build"
+        echo "✔ DONE"
+        ;;
 
-elif [[ "$1" == "attach" ]]; then
-    echo ":: Opening interactive bash shell..."
-    ros_exec -it "exec bash"
-    echo "✔ DONE"
+    attach)
+        ensure_container
+        echo ":: Opening interactive bash shell..."
+        ros_exec -it "exec bash"
+        echo "✔ DONE"
+        ;;
 
-elif [[ "$1" == "launch" ]]; then
-    LAUNCH_DIR="$PROJECT_ROOT/launch"
-    mapfile -t LAUNCH_FILES < <(find "$LAUNCH_DIR" -maxdepth 1 -type f -name "*.py" -printf "%f\n" | sort)
+    launch)
+        ensure_container
+        LAUNCH_DIR="$PROJECT_ROOT/launch"
+        mapfile -t LAUNCH_FILES < <(find "$LAUNCH_DIR" -maxdepth 1 -type f -name "*.py" -printf "%f\n" | sort)
 
-    if [[ ${#LAUNCH_FILES[@]} -eq 0 ]]; then
-        echo "X No launch files found in $LAUNCH_DIR"
-        exit 1
-    fi
-
-    echo ":: Available launch files:"
-    select LAUNCH_FILE in "${LAUNCH_FILES[@]}"; do
-        if [[ -n "$LAUNCH_FILE" ]]; then
-            echo "$LAUNCH_FILE" > "$LAST_LAUNCH_FILE"
-            echo ":: Launching $LAUNCH_FILE..."
-            ros_exec -it "ros2 launch launch/$LAUNCH_FILE"
-            break
-        else
-            echo "X Invalid choice. Try again."
+        if [[ ${#LAUNCH_FILES[@]} -eq 0 ]]; then
+            echo "X No launch files found in $LAUNCH_DIR"
+            exit 1
         fi
-    done
-    echo "✔ DONE"
 
-elif [[ "$1" == "reload" ]]; then
-    echo ":: Rebuilding workspace..."
-    ros_exec "cd /root/ssl-VICE && colcon build"
-    if [[ ! -f "$LAST_LAUNCH_FILE" ]]; then
-        echo ":: No previous launch found. Falling back to 'vice launch'..."
-        exec "$0" launch
-    fi
-    LAUNCH_FILE="$(cat "$LAST_LAUNCH_FILE")"
-    echo ":: Relaunching $LAUNCH_FILE..."
-    ros_exec -it "ros2 launch launch/$LAUNCH_FILE"
-    echo "✔ DONE"
+        echo ":: Available launch files:"
+        select LAUNCH_FILE in "${LAUNCH_FILES[@]}"; do
+            if [[ -n "$LAUNCH_FILE" ]]; then
+                echo "$LAUNCH_FILE" > "$LAST_LAUNCH_FILE"
+                echo ":: Launching $LAUNCH_FILE..."
+                ros_exec -it "ros2 launch launch/$LAUNCH_FILE"
+                break
+            else
+                echo "X Invalid choice. Try again."
+            fi
+        done
+        echo "✔ DONE"
+        ;;
 
-elif [[ "$1" == "topics" ]]; then
-    echo ":: Fetching active ROS 2 topics from container '$CONTAINER_NAME'..."
-
-    mapfile -t TOPICS < <(ros_exec "ros2 topic list" 2>/dev/null)
-
-    if [[ ${#TOPICS[@]} -eq 0 ]]; then
-        echo "X No topics found. Make sure ROS2 nodes are running inside the container."
-        exit 1
-    fi
-
-    echo ":: Available ROS2 topics:"
-    select TOPIC in "${TOPICS[@]}"; do
-        if [[ -n "$TOPIC" ]]; then
-            echo ":: Listening to topic: $TOPIC"
-            echo ":: Press Ctrl+C to stop."
-            ros_exec -it "ros2 topic echo $TOPIC"
-            break
-        else
-            echo "X Invalid selection, try again."
+    reload)
+        ensure_container
+        echo ":: Rebuilding workspace..."
+        ros_exec "cd /root/ssl-VICE && colcon build"
+        if [[ ! -f "$LAST_LAUNCH_FILE" ]]; then
+            echo ":: No previous launch found. Falling back to 'vice launch'..."
+            exec "$0" launch
         fi
-    done
+        LAUNCH_FILE="$(cat "$LAST_LAUNCH_FILE")"
+        echo ":: Relaunching $LAUNCH_FILE..."
+        ros_exec -it "ros2 launch launch/$LAUNCH_FILE"
+        echo "✔ DONE"
+        ;;
 
-else
-    echo "Usage:"
-    echo "  vice build                 # Build workspace"
-    echo "  vice topics                # Echo topics"
-    echo "  vice attach                # Open interactive shell"
-    echo "  vice launch                # Runs launch files"
-    echo "  vice reload                # Rebuild + relaunch last launch file"
-fi
+    run)
+        ensure_container
+        if [[ -n "$2" && -n "$3" ]]; then
+            echo ":: Running $3 from $2..."
+            ros_exec -it "ros2 run $2 $3"
+            echo "✔ DONE"
+        else
+            echo ":: Available packages:"
+            mapfile -t PACKAGES < <(ls -d "$PROJECT_ROOT"/src/*/ 2>/dev/null | xargs -I{} basename {} | sort)
 
+            if [[ ${#PACKAGES[@]} -eq 0 ]]; then
+                echo "X No packages found. Run 'vice build' first."
+                exit 1
+            fi
+
+            select PKG in "${PACKAGES[@]}"; do
+                if [[ -n "$PKG" ]]; then
+                    echo ":: Executables in $PKG:"
+                    mapfile -t EXECUTABLES < <(ros_exec "ros2 pkg executables $PKG" 2>/dev/null | awk '{print $2}')
+
+                    if [[ ${#EXECUTABLES[@]} -eq 0 ]]; then
+                        echo "X No executables found in $PKG."
+                        exit 1
+                    fi
+
+                    select EXEC in "${EXECUTABLES[@]}"; do
+                        if [[ -n "$EXEC" ]]; then
+                            echo ":: Running $EXEC from $PKG..."
+                            ros_exec -it "ros2 run $PKG $EXEC"
+                            echo "✔ DONE"
+                            break
+                        else
+                            echo "X Invalid choice. Try again."
+                        fi
+                    done
+                    break
+                else
+                    echo "X Invalid choice. Try again."
+                fi
+            done
+        fi
+        ;;
+
+    topics)
+        ensure_container
+        echo ":: Fetching active ROS 2 topics from container '$CONTAINER_NAME'..."
+
+        mapfile -t TOPICS < <(ros_exec "ros2 topic list" 2>/dev/null)
+
+        if [[ ${#TOPICS[@]} -eq 0 ]]; then
+            echo "X No topics found. Make sure ROS2 nodes are running inside the container."
+            exit 1
+        fi
+
+        echo ":: Available ROS2 topics:"
+        select TOPIC in "${TOPICS[@]}"; do
+            if [[ -n "$TOPIC" ]]; then
+                echo ":: Listening to topic: $TOPIC"
+                echo ":: Press Ctrl+C to stop."
+                ros_exec -it "ros2 topic echo $TOPIC"
+                break
+            else
+                echo "X Invalid selection, try again."
+            fi
+        done
+        ;;
+
+    stop)
+        if [[ "$(docker ps -q -f name=^${CONTAINER_NAME}$)" != "" ]]; then
+            echo ":: Stopping container '$CONTAINER_NAME'..."
+            docker stop $CONTAINER_NAME > /dev/null
+            echo "✔ Container stopped."
+        else
+            echo "✔ Container '$CONTAINER_NAME' is not running."
+        fi
+        ;;
+
+    start)
+        ensure_container
+        echo "✔ Container '$CONTAINER_NAME' is running."
+        ;;
+
+    restart)
+        echo ":: Restarting container '$CONTAINER_NAME'..."
+        docker restart $CONTAINER_NAME 2>/dev/null || true
+        echo "✔ Container restarted."
+        ;;
+
+    destroy)
+        echo ":: Destroying container and image..."
+        docker stop $CONTAINER_NAME 2>/dev/null || true
+        docker rm $CONTAINER_NAME 2>/dev/null || true
+        docker rmi $IMAGE_NAME 2>/dev/null || true
+        echo "✔ Container and image removed. Next 'vice' command will rebuild from scratch."
+        ;;
+
+    clean)
+        if [[ "$(docker ps -aq -f name=^${CONTAINER_NAME}$)" == "" ]]; then
+            echo "X Container '$CONTAINER_NAME' does not exist. Run 'vice start' first."
+            exit 1
+        fi
+        echo ":: Cleaning build artifacts (build/, install/, log/)..."
+        docker exec $CONTAINER_NAME rm -rf /root/ssl-VICE/build /root/ssl-VICE/install /root/ssl-VICE/log
+        echo "✔ Clean complete. Run 'vice build' to rebuild."
+        ;;
+
+    *)
+        echo "Usage: vice <command>"
+        echo ""
+        echo "Development:"
+        echo "  build              Build the ROS2 workspace"
+        echo "  launch             Select and run a launch file"
+        echo "  reload             Rebuild + relaunch last launch file"
+        echo "  run <pkg> <node>   Run a single node"
+        echo "  attach             Open interactive shell in the container"
+        echo "  topics             List and echo ROS2 topics"
+        echo ""
+        echo "Container management:"
+        echo "  start              Start the container"
+        echo "  stop               Stop the container"
+        echo "  restart            Restart the container"
+        echo "  destroy            Remove container and image completely"
+        echo "  clean              Delete build/, install/, log/"
+        ;;
+esac

--- a/scripts/vice
+++ b/scripts/vice
@@ -9,6 +9,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 IMAGE_NAME="ssl-vice"
 CONTAINER_NAME="vice"
 DOCKERFILE_PATH="$PROJECT_ROOT/Dockerfile"
+LAST_LAUNCH_FILE="$PROJECT_ROOT/.vice_last_launch"
 
 # --- Tip ---
 if [[ ":$PATH:" != *":$PWD/scripts:"* && ":$PATH:" != *":$PWD/scripts/:"* ]]; then
@@ -67,6 +68,7 @@ elif [[ "$1" == "launch" ]]; then
     echo ":: Available launch files:"
     select LAUNCH_FILE in "${LAUNCH_FILES[@]}"; do
         if [[ -n "$LAUNCH_FILE" ]]; then
+            echo "$LAUNCH_FILE" > "$LAST_LAUNCH_FILE"
             echo ":: Launching $LAUNCH_FILE..."
             docker exec -it $CONTAINER_NAME bash -c \
                 "source /opt/ros/humble/setup.bash && \
@@ -77,6 +79,21 @@ elif [[ "$1" == "launch" ]]; then
             echo "X Invalid choice. Try again."
         fi
     done
+    echo "✔ DONE"
+
+elif [[ "$1" == "reload" ]]; then
+    echo ":: Rebuilding workspace..."
+    docker exec $CONTAINER_NAME bash -c "source /opt/ros/humble/setup.bash && cd /root/ssl-VICE && colcon build"
+    if [[ ! -f "$LAST_LAUNCH_FILE" ]]; then
+        echo ":: No previous launch found. Falling back to 'vice launch'..."
+        exec "$0" launch
+    fi
+    LAUNCH_FILE="$(cat "$LAST_LAUNCH_FILE")"
+    echo ":: Relaunching $LAUNCH_FILE..."
+    docker exec -it $CONTAINER_NAME bash -c \
+        "source /opt/ros/humble/setup.bash && \
+         source /root/ssl-VICE/install/local_setup.bash && \
+         ros2 launch launch/$LAUNCH_FILE"
     echo "✔ DONE"
 
 elif [[ "$1" == "topics" ]]; then
@@ -110,5 +127,6 @@ else
     echo "  vice topics                # Echo topics"
     echo "  vice attach                # Open interactive shell"
     echo "  vice launch                # Runs launch files"
+    echo "  vice reload                # Rebuild + relaunch last launch file"
 fi
 


### PR DESCRIPTION
  ## Summary

  - Refactored `vice` script with `ros_exec()` helper to reduce duplicated Docker exec calls
  - Moved container auto-start into `ensure_container()` function for better command flow
  - Added new commands: `run`, `stop`, `start`, `restart`, `destroy`, `clean`, `reload`
  - `vice run` supports interactive package/node selection when called without arguments
  - `vice launch` now uses `-it` flag for proper signal propagation on Ctrl+C
  - `vice attach` now sources ROS + workspace overlay automatically
  - `vice reload` rebuilds and relaunches the last used launch file in one step
  - Fixed `apiNode` Flask thread not shutting down on Ctrl+C (set as daemon thread)
  - Dockerfile now uses `requirements.txt` instead of inline pip install
  - Pinned `protobuf==3.20.*` in requirements.txt for grSim compatibility
  - Added `.devcontainer/devcontainer.json` with Pylance, Ruff, and format-on-save configured
  - Added `docs/archlinux-setup.md` with AUR grSim install, CMake workaround, and Wayland fix
  - Added `docs/vscode-setup.md` with Dev Container and Ruff setup instructions
  - Updated README with Vice CLI documentation and links to setup guides

  ## Test plan

  - [ ] `vice build` compiles the workspace successfully
  - [ ] `vice launch` starts nodes and Ctrl+C shuts them all down cleanly
  - [ ] `vice reload` rebuilds and relaunches without manual steps
  - [ ] `vice run` shows interactive menu when called without arguments
  - [ ] `vice run <pkg> <node>` runs the specified node directly
  - [ ] `vice stop` / `vice start` / `vice restart` manage the container correctly
  - [ ] `vice destroy` removes container and image, next command rebuilds from scratch
  - [ ] `vice clean` removes build artifacts inside the container
  - [ ] `vice attach` drops into a shell with ROS and overlay sourced
  - [ ] Dev Container opens in VS Code with IntelliSense working for ROS2 and system_interfaces